### PR TITLE
Improve usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# Mujoco_manipulator
+# Mujoco Manipulator
+
+This repository provides a minimal example of training a robotic manipulator in the [Robosuite](https://robosuite.ai/) simulator. The agent uses a TD3 style algorithm implemented in PyTorch.
+
+## Installation
+
+Create a Python environment and install the dependencies:
+
+```bash
+pip install -r learning/requirements.txt
+```
+
+## Training
+
+To start training run:
+
+```bash
+python learning/main.py
+```
+
+Training logs are written to the `logs/` directory and model checkpoints are stored in `tmp/td3/`.
+If you are on **macOS**, use the MuJoCo provided `mjpython` interpreter when running any scripts or tests. For example:
+
+```bash
+mjpython learning/main.py
+```
+
+## Evaluation
+
+After training, visualize the learned policy by running:
+
+```bash
+python learning/test.py
+```
+
+This will load the latest checkpoints and render the environment while the agent interacts with it.
+
+## Visualizing with TensorBoard
+
+You can monitor training metrics using [TensorBoard](https://www.tensorflow.org/tensorboard). Run the following command and open the displayed URL in your browser:
+
+```bash
+tensorboard --logdir logs
+```


### PR DESCRIPTION
## Summary
- add installation, training and evaluation instructions
- clarify macOS usage for tests
- mention TensorBoard log visualization

## Testing
- `pytest -q`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68587f447488832a90f2cf94adb70b5c